### PR TITLE
Fix default ExportSpriteSheet type

### DIFF
--- a/Animation Export Groups, Layers & Tags/Export Animation.lua
+++ b/Animation Export Groups, Layers & Tags/Export Animation.lua
@@ -4,7 +4,7 @@ function exportLayerAndTag(tempLayer, tempTag, tempColumnNumbers, tempFileName)
     app.command.ExportSpriteSheet{
 		ui=false,
 		askOverwrite=false,
-		type=SpriteSheetType.Rows,  	-- Change this if you want to change how the exported sprite is displayed.
+		type=SpriteSheetType.ROWS,  	-- Change this if you want to change how the exported sprite is displayed.
 		columns=tempColumnNumbers,    	-- Use one of these options(HORIZONTAL, VERTICAL, ROWS, COLUMNS, PACKED)
 		rows=tempColumnNumbers,			-- You can learn more here
 		bestFit=false;					--https://github.com/aseprite/api/blob/main/api/command/ExportSpriteSheet.md#exportspritesheet


### PR DESCRIPTION
Hey, great script, thanks! I had to change this value for exports to contain all the frames in a given tag (1.3-beta21x64 on macOS).